### PR TITLE
DOC: update How-to-use-post-processing.html import paths

### DIFF
--- a/docs/manual/ar/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ar/introduction/How-to-use-post-processing.html
@@ -24,9 +24,9 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
 		</code>
 
 		<p>
@@ -80,7 +80,7 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
 		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
 
 		// later in your init routine


### PR DESCRIPTION
Related issue: Imports not workin in current verison

**Description**

changed the import path to three/examples/jsm/postprocessing/..
